### PR TITLE
fix: move card ordering

### DIFF
--- a/src/models/card.js
+++ b/src/models/card.js
@@ -86,25 +86,32 @@ export const card = {
       const { order: oldOrder, ...cardBeingMoved } = state.cards[
         sourceList
       ].find(x => x._id === cardId);
-      const moveUp = newOrder > oldOrder;
+      // const moveUp = newOrder > oldOrder;
 
       if (sourceList === destList) {
         console.log(`move ${oldOrder} -> ${newOrder}`);
+        // remove from list
+        let newSourceList = state.cards[sourceList].filter(
+          x => x._id !== cardId
+        );
+        // update index after removal
+        newSourceList = newSourceList.map(x => {
+          if (x.order > oldOrder) x.order -= 1;
+          return x;
+        });
+        // update index after add
+        newSourceList = newSourceList.map(x => {
+          if (x.order >= newOrder) x.order += 1;
+          return x;
+        });
+        // re-add
+        cardBeingMoved.order = newOrder;
+        newSourceList.push(cardBeingMoved);
         return {
           ...state,
           cards: {
             ...state.cards,
-            [sourceList]: state.cards[sourceList].map(x => {
-              if (x._id === cardId) x.order = newOrder;
-              else if (moveUp) {
-                // move card up
-                if (x.order >= newOrder && x.order < oldOrder) x.order += 1;
-              } else {
-                // move card down
-                if (x.order <= newOrder && x.order > oldOrder) x.order -= 1;
-              }
-              return x;
-            })
+            [sourceList]: newSourceList
           }
         };
       } else {
@@ -243,7 +250,6 @@ export const card = {
           listId
         }
       });
-      console.log(card);
       yield put({
         type: 'card/putListCard',
         payload: {


### PR DESCRIPTION
This commit resolve the bug when move card up down of a list. Card order
can be fix by updating through these steps:

1. Remove the card out of the list
2. Update index of the list after remove, (> old order)
3. Update index of the list after add, (>= new order)
4. Add the card back the list, with updated order